### PR TITLE
Fix indexing of `<h2>` sections

### DIFF
--- a/docs/.vitepress/markdown/headers.ts
+++ b/docs/.vitepress/markdown/headers.ts
@@ -18,13 +18,48 @@ import type { MarkdownRenderer } from 'vitepress'
 const excluded = ['Credits']
 
 export const headersPlugin = (md: MarkdownRenderer) => {
-  // Add the Feedback component after the heading and close the container
-  md.renderer.rules.heading_close = (tokens, idx, options, env, self) => {
+  // Add the Feedback component in the heading, before the link.
+  //
+  // Adding it after the link is closed prevents vitepress from properly
+  // indexing the file's content.
+
+  md.renderer.rules.heading_open = (tokens, idx, options, env, self) => {
     const result = self.renderToken(tokens, idx, options)
-    const heading = tokens[idx - 1]
+
+    const idxClose =
+      idx +
+      tokens.slice(idx).findIndex((token) => token.type === 'heading_close')
+    if (idxClose <= idx) return result
+
     const level = tokens[idx].tag.slice(1)
     if (excluded.includes(env.frontmatter.title) || level !== '2') return result
 
-    return `<Feedback heading="${heading.content}" />${result}`
+    // Find the token for the link.
+    //
+    // The token after `heading_open` contains the link as a child token.
+    const children = tokens[idx + 1].children || []
+    const linkOpenToken = children.find((c) => c.type === 'link_open')
+    if (!linkOpenToken) return result
+
+    const heading = tokens[idxClose - 1]
+
+    linkOpenToken.meta = linkOpenToken.meta || {}
+    linkOpenToken.meta.feedback = {
+      heading: heading.content
+    }
+
+    return result
+  }
+
+  md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+    const result = self.renderToken(tokens, idx, options)
+
+    const meta = tokens[idx].meta
+    if (!meta || !meta.feedback) return result
+
+    const heading = meta.feedback.heading || ''
+    if (!heading) return result
+
+    return `<Feedback heading="${heading}" />${result}`
   }
 }


### PR DESCRIPTION
## Context

`<h2>` headings have a [button for feedback](https://github.com/wotakumoe/wotaku/blob/5eaccedfc7ac133df062408e47793aa612cc9ff4/docs/.vitepress/theme/components/Feedback.vue), it is [configured in the theme](https://github.com/wotakumoe/wotaku/blob/main/docs/.vitepress/configs/shared.ts#L357) as a [plugin for the markdown renderer](https://github.com/wotakumoe/wotaku/blob/5eaccedfc7ac133df062408e47793aa612cc9ff4/docs/.vitepress/markdown/headers.ts).

## Problem

<details>

<summary>Screenshot of search not showing `General Download` section</summary>

![search-not-working](https://github.com/user-attachments/assets/cfb3e602-bd76-460c-b2cc-7a186e92541a)

</details>

Some sections are not being properly indexed, so it is not possible to search (for example) anything under the `## General Download` section of the `docs/games.md` file.

The reason seems to be that Vitepress expects the headings to conform to [a specific regexp](https://github.com/vuejs/vitepress/blob/v1.5.0/src/node/plugins/localSearchPlugin.ts#L214), and this regexp expects that the heading is closed by `</a></h2>`.

The current `headersPlugin` ("current" as in "before this PR") is adding a button between that `</a>` and the `</h2>`, so the regexp no longer matches, and it causes the function to [skip indexing that section](https://github.com/vuejs/vitepress/blob/v1.5.0/src/node/plugins/localSearchPlugin.ts#L231).

Or that's my understanding, at least.

## Changes in this PR

This PR moves the `Feedback` component to _before_ opening that link in the heading. For that, we're doing two things:

1. Hooking onto the `heading_open` rule of the markdown renderer, look ahead to search the token for the link's opening tag, and set its `meta.feedback.heading` to the heading needed by the `Feedback` component ([the `meta` property exists for this purpose](https://github.com/markdown-it/markdown-it/blob/0fe7ccb4b7f30236fb05f623be6924961d296d3d/lib/token.mjs#L95)).

2. Hook onto the `link_open` rule, and if it has an existing and non-empty `meta.feedback.heading`, then include the `Feedback` component before the rendered result. Otherwise, just render it without changing anything.

> [!NOTE]
> Since the `link_open` token is a child of another token, it doesn't seem possible to easily look back with `tokens[idx - something]`, so that's why the two step process. If that were possible, the code could probably be simplified.

Visually there's not much difference, if any.

<details>

<summary>Screenshots of heading</summary>

![collapsed](https://github.com/user-attachments/assets/af2964f0-1b3b-4e63-badb-a3614b69bb78)

![expanded](https://github.com/user-attachments/assets/2026d297-80d3-431b-affc-ebacd6e150dd)

</details>

<details>

<summary>And the search now works</summary>

![Search](https://github.com/user-attachments/assets/598cd669-44c5-4b1a-90c1-c60e1824e36d)

</details>