### PR TITLE
Bump various useful Japanese resources to the top

### DIFF
--- a/docs/japan/language.md
+++ b/docs/japan/language.md
@@ -18,10 +18,10 @@ If you're knowledgeable in Japanese, consider contributing to the wiki. We could
 
 ## Starter Guide
 - [TheMoeWay Guide](https://learnjapanese.moe/) :s:
-- [Tatsumoto's Guide](https://tatsumoto.neocities.org/)
-- [Kuri's Immersion-Based Japanese Learning](https://donkuri.github.io/learn-japanese/)
+- [Kuri's Immersion-Based Japanese Learning](https://donkuri.github.io/learn-japanese/) :s:
 - [Acquiring Japanese Efficiently](https://docs.google.com/document/d/1LH82FjsCqCgp6-TFqUcS_EB15V7sx7O1VCjREp6Lexw/edit)
 - [DJT GUIDE](https://djtguide.neocities.org/guide)
+- [Tatsumoto's Guide](https://tatsumoto.neocities.org/)
 
 :::details More
 
@@ -87,7 +87,6 @@ If you're knowledgeable in Japanese, consider contributing to the wiki. We could
   - [Original version](https://www.joyokanji.com/ulrikes-mnemonics)
   - [Carlos version](https://japanesestudies.github.io/ulrikes-mnemonics/)
 - [Marshall's Site](https://marshallyin.com/) :fm:<tooltip>Marshall's site contain almost everything. So to avoid dupe, it will be linked once.</tooltip>
-- [THE KANJI VISUAL LANGUAGE PROJECT](https://kvlp.org/)
 - [Proverb encyclopedia](https://proverb-encyclopedia.com/)
 
 ### Dictionary
@@ -271,6 +270,10 @@ Check out the [**Japanese Mega Learning Pack**](https://links.gamesdrive.net/#/l
 
 
 ## Others
+
+### Resource Lists
+[Kuri's Japanese Resources](https://github.com/donkuri/japanese-resources) :s:
+[TMW's Resources](https://learnjapanese.moe/resources/)
 
 ### Communities
 | Category      | Links                                                                                                                                                          |

--- a/docs/japan/software.md
+++ b/docs/japan/software.md
@@ -24,7 +24,8 @@ og:
 ___
 #### Guide
 - [Anki Manual](https://docs.ankiweb.net/)
-- [Tatsumoto](https://tatsumoto.neocities.org/blog/setting-up-anki) :s:
+- [Kuri's Setup Guide](https://donkuri.github.io/learn-japanese/setup/#anki-setup) :s:
+- [Tatsumoto](https://tatsumoto.neocities.org/blog/setting-up-anki)
 - [jp-mining-note](https://arbyste.github.io/jp-mining-note/) <Badge type="tip" text="original" link="https://aquafina-water-bottle.github.io/jp-mining-note/"/>
 - [Xelieu's Modified Anime Card](https://xelieu.github.io/jp-lazy-guide/)
 - [vladsperspective](https://vladsperspective.wordpress.com/2020/07/15/using-anime-decks-subs2srs-mediafire-premade-decks/)
@@ -67,9 +68,9 @@ ___
 - [Kanji de Go](https://github.com/MarvNC/kanjidego-yomitan-anki)
 ___
 #### Vocab
+- [Kaishi](https://github.com/donkuri/Kaishi) :s: <Badge type="info" text="Beginner" />
 - [Anime decks (Official AnkiWeb)](https://ankiweb.net/shared/decks?search=anime)
 - [Anime decks (Sub2Srs)](https://links.gamesdrive.net/#/link/aHR0cHM6Ly93d3cubWVkaWFmaXJlLmNvbS9mb2xkZXIvcDE3ZzV1azRwaGI0MS9Vc2VyX1VwbG9hZGVkX0Fua2lfRGVja3M)
-- [Kaishi](https://github.com/donkuri/Kaishi) <Badge type="info" text="Beginner" />
 - [Core 2k/6k Optimized Japanese Vocabulary Anki](https://docs.google.com/document/d/1zyyuiWkiz2IF2CCROeJebl8mgRdHBqNfS5D7MFjDTzE/edit) 
 - [DoJG Deck](https://dojgdeck.neocities.org/) 
 - [Japanese course based on Tae Kim's grammar guide & anime](https://ankiweb.net/shared/info/911122782) 
@@ -166,13 +167,11 @@ ___
 
 
 ### Browser
-
-- [Yomitan](https://yomitan.wiki/) :ff::cr: [:gh:](https://github.com/themoeway/yomitan) <Badge type="tip" text="Guide" link="https://learnjapanese.moe/yomichan/" /><tooltip>Pop-up dictionary</tooltip>
+- [Yomitan](https://yomitan.wiki/) :s: :ff::cr: [:gh:](https://github.com/yomidevs/yomitan) <Badge type="tip" text="Guide" link="https://learnjapanese.moe/yomichan/" /><tooltip>Pop-up dictionary. Can be used on mobile, with browsers that support extensions.</tooltip>
     - [Yomitan Dictionaries](https://github.com/MarvNC/yomichan-dictionaries/)
     - [Yomitan Grammar Dictionaries](https://github.com/aiko-tanaka/Grammar-Dictionaries)
     - [Local Audio Server for Yomichan](https://github.com/themoeway/local-audio-yomichan)
     - [VNDB Names for Yomitan](https://github.com/kaanium/VNDB-Names-for-Yomitan)
-- [Rikitan](https://github.com/Ajatt-Tools/rikaitan) :ff::cr:<Badge type="tip" text="Guide" link="https://tatsumoto.neocities.org/blog/setting-up-yomichan"/> <Badge type="tip" text="Dictionaries" link="https://tatsumoto.neocities.org/blog/yomichan-and-epwing-dictionaries" /><tooltip>Pop-up dictionary</tooltip>
 - [10ten Japanese Reader](https://github.com/birchill/10ten-ja-reader) :ff::cr::mingcute-safari-fill:<tooltip>Pop-up dictionary</tooltip>
 - [ASB Auto Subs](https://github.com/GodPepe7/asb-auto-subs) :ff::cr:<tooltip>Jimaku subs in anime sites</tooltip>
 - [Japanese.io](https://www.japanese.io/) :cr:<tooltip>Pop-up dictionary</tooltip>


### PR DESCRIPTION
software.md:
- Removed rikaitan and removed stars for tatsumoto links (website for AJATT-Tools). It is known that they directly steal the source code from [yomitan](https://yomitan.wiki) and rebrands under rikaitan. No point in promoting this.
- Added some stars for more universally accepted good guides and programs.
- Added donkuri's setup guide for anki as a star, as it is very comprehensive.

language.md:
- Added "Other Resources" section and included a link to both TMW and Kuri's Japanese resources page, they also have a comprehensive list of resources and I'm not sure if it would be worth it to include all of that here since a lot of it might conflict or clutter things.
- Starred donkuri's guide as it is very similar to TMW's guide and is being actively updated.
- Moved tatsumoto's guide down because of their affiliation with rikaitan.

Not really sure where to put yomitan, as it supports basically all things in software.md (anki, mobile, etc).