### PR TITLE
feat: add sidebar navigation on homepage

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -36,6 +36,7 @@ const { Layout } = DefaultTheme
 // Home sidebar menu
 const isHome = computed(() => frontmatter.value.layout === 'home')
 const homeSidebarOpen = ref(false)
+const sidebarRef = ref<HTMLElement | null>(null)
 const homeSidebarGroups = getSidebarGroups(sidebar as any)
 const logoSrc = computed(() =>
   typeof theme.value.logo === 'string' ? theme.value.logo : theme.value.logo?.src
@@ -44,6 +45,10 @@ const logoSrc = computed(() =>
 watch(() => route.path, () => {
   homeSidebarOpen.value = false
 })
+
+function onSidebarEnter() {
+  sidebarRef.value?.focus()
+}
 
 interface BreadcrumbItem {
   text: string
@@ -168,6 +173,32 @@ const reloadTakodachi = () => {
 onMounted(() => {
   if (import.meta.env.SSR) return
 
+  // Arrow key scrolling + Escape close for desktop sidebar
+  useEventListener(document, 'keydown', (e: KeyboardEvent) => {
+    if (!homeSidebarOpen.value || !sidebarRef.value) return
+    if (e.key === 'Escape') {
+      homeSidebarOpen.value = false
+      return
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      sidebarRef.value.scrollBy({ top: 60, behavior: 'smooth' })
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      sidebarRef.value.scrollBy({ top: -60, behavior: 'smooth' })
+    }
+  })
+
+  // Close home NavScreen on outside click
+  useEventListener(document, 'click', (e: Event) => {
+    if (!isHome.value) return
+    const screen = document.getElementById('VPNavScreen')
+    if (!screen) return
+    const hamburger = document.querySelector('.VPNavBarHamburger')
+    if (screen.contains(e.target as Node) || hamburger?.contains(e.target as Node)) return
+    requestAnimationFrame(() => (hamburger as HTMLElement)?.click())
+  })
+
   // Storage changed in other documents.
   useEventListener(window, 'storage', () => {
     reloadTakodachi()
@@ -200,7 +231,7 @@ onUnmounted(() => {
           top: `${position.y}px`
         }"
       />
-      <!-- Home sidebar menu (desktop only) -->
+      <!-- Home sidebar menu -->
       <template v-if="isHome">
         <Transition name="home-fade">
           <div
@@ -209,8 +240,14 @@ onUnmounted(() => {
             @click="homeSidebarOpen = false"
           />
         </Transition>
-        <Transition name="home-slide">
-          <aside v-if="homeSidebarOpen" class="home-sidebar" @click.stop>
+        <Transition name="home-slide" @after-enter="onSidebarEnter">
+          <aside
+            v-if="homeSidebarOpen"
+            ref="sidebarRef"
+            class="home-sidebar"
+            tabindex="-1"
+            @click.stop
+          >
             <div class="home-sidebar-header">
               <a href="/" class="home-sidebar-logo">
                 <img v-if="logoSrc" :src="logoSrc" class="home-sidebar-logo-img" alt="Logo" />
@@ -273,8 +310,13 @@ onUnmounted(() => {
     <template #nav-bar-content-after>
       <NolebaseEnhancedReadabilitiesMenu />
     </template>
+    <template #nav-screen-content-before>
+      <nav v-if="isHome" id="VPSidebarNavMobile" class="home-screen-nav">
+        <VPSidebarGroup :items="homeSidebarGroups" />
+      </nav>
+    </template>
     <template #nav-screen-content-after>
-      <NolebaseEnhancedReadabilitiesScreenMenu />
+      <NolebaseEnhancedReadabilitiesScreenMenu v-if="!isHome" />
     </template>
     <template #nav-bar-title-before>
       <span

--- a/docs/.vitepress/theme/styles/style.scss
+++ b/docs/.vitepress/theme/styles/style.scss
@@ -612,7 +612,8 @@ table tr:nth-child(odd) {
   }
 }
 
-#VPSidebarNav > .group {
+#VPSidebarNav > .group,
+#VPSidebarNavMobile > .group {
   @apply border-t-0 min-h-11 pt-2.25;
 
   & > .VPSidebarItem {
@@ -1225,6 +1226,20 @@ table tr:nth-child(odd) {
   @apply ml-2 pl-0!;
 }
 
+%thin-scrollbar {
+  scrollbar-width: thin;
+  &::-webkit-scrollbar { width: 8px; }
+  &::-webkit-scrollbar-track { background: transparent; }
+  &::-webkit-scrollbar-thumb { border-radius: 4px; }
+}
+
+%thin-scrollbar-narrow {
+  scrollbar-width: thin;
+  &::-webkit-scrollbar { width: 6px; }
+  &::-webkit-scrollbar-track { background: transparent; }
+  &::-webkit-scrollbar-thumb { border-radius: 3px; background-color: var(--vp-c-divider); }
+}
+
 /* Home sidebar menu button in navbar */
 .home-menu-btn {
   display: none;
@@ -1255,6 +1270,7 @@ table tr:nth-child(odd) {
   background-color: rgba(0, 0, 0, 0.6);
 }
 
+/* Home desktop sidebar (left slideout) */
 .home-sidebar {
   position: fixed;
   top: 0;
@@ -1269,6 +1285,7 @@ table tr:nth-child(odd) {
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: contain;
+  @extend %thin-scrollbar;
 
   .dark & {
     box-shadow: var(--vp-shadow-1);
@@ -1279,7 +1296,6 @@ table tr:nth-child(odd) {
   position: sticky;
   top: 0;
   z-index: 1;
-  padding: 0;
   height: var(--vp-nav-height);
   display: flex;
   align-items: center;
@@ -1306,6 +1322,7 @@ table tr:nth-child(odd) {
   padding-top: 10px;
 }
 
+/* Desktop sidebar transitions */
 .home-fade-enter-active,
 .home-fade-leave-active {
   transition: opacity 0.25s;
@@ -1328,4 +1345,64 @@ table tr:nth-child(odd) {
 .home-slide-leave-to {
   transform: translateX(-100%);
   opacity: 0;
+}
+
+/* Hide navbar border when home NavScreen is open */
+.VPNavBar.home.screen-open {
+  border-bottom: none !important;
+}
+
+/* Home NavScreen: restyle as left-aligned floating panel matching VPSidebar */
+.VPNavScreen:has(.home-screen-nav) {
+  @apply bg-white/85 dark:bg-neutral-800/85
+    border dark:border-neutral-700 border-neutral-200
+    rounded-3xl backdrop-blur shadow-lg;
+  padding: 0 !important;
+  left: 0.5rem !important;
+  right: auto !important;
+  top: 0.5rem !important;
+  bottom: 0.5rem !important;
+  width: calc(100vw - 64px) !important;
+  max-width: 320px !important;
+  overflow-x: hidden !important;
+  @extend %thin-scrollbar-narrow;
+
+  & > * {
+    max-width: 100% !important;
+    padding: 16px 16px 0 !important;
+    display: flex !important;
+    flex-direction: column !important;
+    min-height: 100%;
+  }
+
+  .VPNavScreenAppearance {
+    margin-top: 24px !important;
+  }
+
+  .VPNavScreenSocialLinks {
+    margin-top: auto !important;
+    padding: 16px 0 !important;
+    display: flex;
+    justify-content: center;
+  }
+}
+
+.home-screen-nav {
+  padding-top: 8px;
+}
+
+/* Override NavScreen fade transition to slide-from-left on home */
+.VPNavScreen:has(.home-screen-nav) {
+  &.fade-enter-active,
+  &.fade-leave-active {
+    transition: transform 0.3s cubic-bezier(0.19, 1, 0.22, 1), opacity 0.25s !important;
+
+    .container { transform: none !important; }
+  }
+
+  &.fade-enter-from,
+  &.fade-leave-to {
+    transform: translateX(-100%) !important;
+    opacity: 0 !important;
+  }
 }


### PR DESCRIPTION
Adds sidebar navigation to the homepage on both desktop and mobile.

- Desktop: hamburger icon in navbar opens left slideout sidebar
- Mobile: NavScreen restyled as floating panel with sidebar categories