### PR TITLE
document Hayase for iOS

### DIFF
--- a/docs/software.md
+++ b/docs/software.md
@@ -161,6 +161,7 @@ Check out [**CFW**](https://ios.cfw.guide/), [**JCoinx**](https://jcionx.github.
 - [Luna](https://github.com/cranci1/Luna) [:e:](/ext/ios#sora)
 - [Mangayomi](https://github.com/kodjodevf/mangayomi) [:e:](/ext/mangayomi)
 - [AnymeX](https://anymex.vercel.app/) [:src:](https://github.com/RyanYuuki/AnymeX) [:e:](/ext/mangayomi)
+- [Hayase](https://hayase.watch/) :paid::cs::n: [:src:](https://github.com/hayase-app) [:e:](/ext/misc#hayase)
 
 ::: details "iOS app not working. What should i do?"
 


### PR DESCRIPTION
<img width="282" height="217" alt="image" src="https://github.com/user-attachments/assets/2e983250-28b3-4692-8ac2-464b25823127" />
the spaces are kinda funky
<img width="157" height="62" alt="image" src="https://github.com/user-attachments/assets/f4698f3a-31d2-4b6b-be73-1eac959098d3" />
but i simply copied what other sources in the repo do 1:1:
<img width="152" height="60" alt="image" src="https://github.com/user-attachments/assets/dd2bf830-e704-42fc-9e3b-9d60b8478d22" />

there's no icon for sideloading, and now that iOS allows sideloading I expect there will be an explosion of apps so it should be considered