### PR TITLE
Fix Incomplete Scroll Positioning for Collapsibles

### DIFF
--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -52,33 +52,50 @@ const openCollapsibles = () => {
   const target = document.getElementById(decodeURIComponent(hash)) || document.getElementById(hash)
   if (!target) return
 
+  let scrollTarget = target
   let el: HTMLElement | null = target
+
   while ((el = el.closest('details'))) {
     el.open = true
+    scrollTarget = el
     el = el.parentElement
   }
 
   if (/^H[1-6]$/.test(target.tagName)) {
-    const level = parseInt(target.tagName[1])
+    const level = +target.tagName[1]
     let sibling = target.nextElementSibling
 
     while (sibling) {
-      if (/^H[1-6]$/.test(sibling.tagName)) {
-        if (parseInt(sibling.tagName[1]) <= level) break
-      }
+      if (/^H[1-6]$/.test(sibling.tagName) && +sibling.tagName[1] <= level) break
 
       if (sibling.tagName === 'DETAILS') {
         (sibling as HTMLDetailsElement).open = true
+        if (scrollTarget === target) scrollTarget = sibling as HTMLElement
       }
 
-      const nested = sibling.querySelectorAll('details')
+      const nested = sibling.querySelectorAll<HTMLDetailsElement>('details')
       for (let i = 0; i < nested.length; i++) {
         nested[i].open = true
+        if (scrollTarget === target) scrollTarget = nested[i]
       }
 
       sibling = sibling.nextElementSibling
     }
   }
+
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const navOffset = document.querySelector<HTMLElement>('.VPNavBar')?.offsetHeight || 0
+
+      window.scrollTo({
+        top: scrollTarget.getBoundingClientRect().top + window.scrollY - navOffset,
+        behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth'
+      })
+
+      scrollTarget.setAttribute('tabindex', '-1')
+      scrollTarget.focus({ preventScroll: true })
+    })
+  })
 }
 
 watch(() => route.data, async () => {

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -52,44 +52,39 @@ const openCollapsibles = () => {
   const target = document.getElementById(decodeURIComponent(hash)) || document.getElementById(hash)
   if (!target) return
 
-  let scrollTarget = target
-  let el: HTMLElement | null = target
+  let scrollTarget: HTMLElement = target
 
-  while ((el = el.closest('details'))) {
+  for (let el = target.closest('details'); el; el = el.parentElement?.closest('details')) {
     el.open = true
     scrollTarget = el
-    el = el.parentElement
   }
 
   if (/^H[1-6]$/.test(target.tagName)) {
     const level = +target.tagName[1]
-    let sibling = target.nextElementSibling
 
-    while (sibling) {
-      if (/^H[1-6]$/.test(sibling.tagName) && +sibling.tagName[1] <= level) break
+    for (let sib = target.nextElementSibling; sib; sib = sib.nextElementSibling) {
+      if (/^H[1-6]$/.test(sib.tagName) && +sib.tagName[1] <= level) break
 
-      if (sibling.tagName === 'DETAILS') {
-        (sibling as HTMLDetailsElement).open = true
-        if (scrollTarget === target) scrollTarget = sibling as HTMLElement
+      if (sib.tagName === 'DETAILS') {
+        (sib as HTMLDetailsElement).open = true
+        if (scrollTarget === target) scrollTarget = sib as HTMLElement
       }
 
-      const nested = sibling.querySelectorAll<HTMLDetailsElement>('details')
+      const nested = sib.querySelectorAll<HTMLDetailsElement>('details')
       for (let i = 0; i < nested.length; i++) {
         nested[i].open = true
         if (scrollTarget === target) scrollTarget = nested[i]
       }
-
-      sibling = sibling.nextElementSibling
     }
   }
 
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
-      const navOffset = document.querySelector<HTMLElement>('.VPNavBar')?.offsetHeight || 0
+      scrollTarget.style.scrollMarginTop = 'var(--vp-nav-height)'
 
-      window.scrollTo({
-        top: scrollTarget.getBoundingClientRect().top + window.scrollY - navOffset,
-        behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth'
+      scrollTarget.scrollIntoView({
+        behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+        block: 'start'
       })
 
       scrollTarget.setAttribute('tabindex', '-1')

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -45,63 +45,88 @@ watch(() => route.path, () => {
   homeSidebarOpen.value = false
 })
 
-const openCollapsibles = () => {
-  const hash = window.location.hash.slice(1)
-  if (!hash) return
+let searchNavigated = false
 
-  const target = document.getElementById(decodeURIComponent(hash)) || document.getElementById(hash)
-  if (!target) return
+if (!import.meta.env.SSR) {
+  useEventListener(window, 'search-nav', () => {
+    searchNavigated = true
+    tryOpenCollapsibles()
+  })
+}
 
-  let scrollTarget: HTMLElement = target
+const openCollapsibles = (target: HTMLElement) => {
+  let scrollTarget = target
+  let el: HTMLElement | null = target
 
-  for (let el = target.closest('details'); el; el = el.parentElement?.closest('details')) {
+  while ((el = el.closest('details'))) {
     el.open = true
     scrollTarget = el
+    el = el.parentElement
   }
 
-  if (/^H[1-6]$/.test(target.tagName)) {
-    const level = +target.tagName[1]
+  const tagName = target.tagName
+  if (tagName.length === 2 && tagName[0] === 'H') {
+    const level = +tagName[1]
+    if (level >= 1 && level <= 6) {
+      let sibling = target.nextElementSibling
 
-    for (let sib = target.nextElementSibling; sib; sib = sib.nextElementSibling) {
-      if (/^H[1-6]$/.test(sib.tagName) && +sib.tagName[1] <= level) break
+      while (sibling) {
+        const siblingTag = sibling.tagName
+        if (siblingTag.length === 2 && siblingTag[0] === 'H' && +siblingTag[1] <= level) break
 
-      if (sib.tagName === 'DETAILS') {
-        (sib as HTMLDetailsElement).open = true
-        if (scrollTarget === target) scrollTarget = sib as HTMLElement
-      }
+        if (siblingTag === 'DETAILS') {
+          (sibling as HTMLDetailsElement).open = true
+          if (scrollTarget === target) scrollTarget = sibling as HTMLElement
+        }
 
-      const nested = sib.querySelectorAll<HTMLDetailsElement>('details')
-      for (let i = 0; i < nested.length; i++) {
-        nested[i].open = true
-        if (scrollTarget === target) scrollTarget = nested[i]
+        const nested = sibling.getElementsByTagName('details')
+        for (let i = 0, len = nested.length; i < len; i++) {
+          nested[i].open = true
+          if (scrollTarget === target) scrollTarget = nested[i]
+        }
+
+        sibling = sibling.nextElementSibling
       }
     }
   }
 
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
-      scrollTarget.style.scrollMarginTop = 'var(--vp-nav-height)'
-
-      scrollTarget.scrollIntoView({
-        behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
-        block: 'start'
+      const navBar = document.querySelector<HTMLElement>('.VPNavBar')
+      const navOffset = navBar ? navBar.offsetHeight : 0
+      window.scrollTo({
+        top: scrollTarget.getBoundingClientRect().top + window.scrollY - navOffset,
+        behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth'
       })
-
       scrollTarget.setAttribute('tabindex', '-1')
       scrollTarget.focus({ preventScroll: true })
     })
   })
 }
 
-watch(() => route.data, async () => {
+const tryOpenCollapsibles = async () => {
+  if (!searchNavigated) return
   await nextTick()
-  openCollapsibles()
-})
 
-watch(() => route.hash, async () => {
-  await nextTick()
-  openCollapsibles()
-})
+  requestAnimationFrame(() => {
+    const hash = window.location.hash.slice(1)
+    if (!hash) {
+      searchNavigated = false
+      return
+    }
+
+    const id = decodeURIComponent(hash)
+    const target = document.getElementById(id) || document.getElementById(hash)
+
+    if (target) {
+      openCollapsibles(target)
+      searchNavigated = false
+    }
+  })
+}
+
+watch(() => route.data, tryOpenCollapsibles, { flush: 'post' })
+watch(() => route.hash, tryOpenCollapsibles, { flush: 'post' })
   
 function onSidebarEnter() {
   sidebarRef.value?.focus()
@@ -229,22 +254,6 @@ const reloadTakodachi = () => {
 
 onMounted(() => {
   if (import.meta.env.SSR) return
-  useEventListener(document, 'click', async (e: MouseEvent) => {
-    if ((e.target as HTMLElement).closest('a.result')) {
-      await nextTick()
-      requestAnimationFrame(() => requestAnimationFrame(openCollapsibles))
-    }
-  })
-
-  useEventListener(document, 'keydown', async (e: KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      const searchBox = document.querySelector('.VPLocalSearchBox') || document.querySelector('.VPNavBarSearch')
-      if (searchBox && searchBox.contains(e.target as Node)) {
-        await nextTick()
-        requestAnimationFrame(() => requestAnimationFrame(openCollapsibles))
-      }
-    }
-  })
 
   // Arrow key scrolling + Escape close for sidebars and content
   let activeScrollTarget: HTMLElement | Window = window

--- a/docs/.vitepress/theme/components/Search.vue
+++ b/docs/.vitepress/theme/components/Search.vue
@@ -417,10 +417,16 @@ onKeyStroke('Enter', (e) => {
   }
 
   if (selectedPackage) {
+    window.dispatchEvent(new CustomEvent('search-nav'))
     router.go(selectedPackage.id)
     showSearch.value = false
   }
 })
+
+function onResultClick() {
+  window.dispatchEvent(new CustomEvent('search-nav'))
+  showSearch.value = false
+}
 
 onKeyStroke('Escape', () => {
   showSearch.value = false
@@ -723,7 +729,7 @@ function onMouseMove(e: MouseEvent) {
                   @mouseenter="!disableMouseOver &&
                   (selectedIndex = index + 1)"
                   @focusin="selectedIndex = index + 1"
-                  @click="showSearch = false"
+                  @click="onResultClick"
                   :data-index="index + 1"
                 >
                   <div>


### PR DESCRIPTION
This uses a double requestAnimationFrame to wait for DOM repaints so the browser can calculate the correct top offset for newly expanded elements before scrolling.